### PR TITLE
Change Private CIDR to List

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "subnets" {
 
 variable "private_cidr" {
   description = "VPC private addressing, used for a security group"
-  type        = "string"
+  type        = "list"
 }
 
 variable "redshift_vpc_id" {


### PR DESCRIPTION
This change allows private_cidr to be a list rather than a string. The change brings the configuration in line with the RDS community module which allows for multiple CIDRs to be specified.