### PR TITLE
Added encryption support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,11 @@ resource "aws_redshift_cluster" "main_redshift_cluster" {
   }
   
   tags = "${var.default_tags}"
+
+  # Encryption
+  encrypted  = "${var.encrypted}"
+  kms_key_id = "${var.kms_key_id}"
+
 }
 
 resource "aws_redshift_parameter_group" "main_redshift_cluster" {

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,13 @@ variable "wlm_json_configuration" {
 variable "default_tags" {
   type = "map"
 }
+
+variable "encrypted" {
+  description = "(Optional) If true , the data in the cluster is encrypted at rest."
+  default     = false
+}
+
+variable "kms_key_id" {
+  description = "(Optional) The ARN for the KMS encryption key. When specifying kms_key_id, encrypted needs to be set to true."
+  default     = ""
+}


### PR DESCRIPTION
I wanted my redshift database(s) to be encrypted by default.If needed we can even give a kms_key_id.